### PR TITLE
Add 2.2 Artifacts

### DIFF
--- a/docs/2.2/Artifacts.md
+++ b/docs/2.2/Artifacts.md
@@ -1635,13 +1635,16 @@ Artifacts are unique custom items with enchantments and/or attribute bonuses. Un
 
 ## Rhalon's Chestplate
 
-|     |     |
-| --- | --- |
+|                 |                   |
+| --------------- | ----------------- |
+| Armor           | 8                 |
+| Armor Toughness | 2                 |
+| Enchants        | Fire Protection 4 |
 
-|            | **Lore and how to Obtain** |
-| ---------- | -------------------------- |
-| **Lore**   |                            |
-| **Obtain** |                            |
+|            | **Lore and how to Obtain**                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Chestplate worn by Rhalon, greatest warrior of the Burnt God's forces. This armor has seen many battles. May it see many more.             |
+| **Obtain** | Located in the Insohmic Coven of Potentia on the east coast of the islands to the east of Mossfield. Dropped by Rhalon, The First General. |
 
 ## Rocky Helmet
 

--- a/docs/2.2/Artifacts.md
+++ b/docs/2.2/Artifacts.md
@@ -12,6 +12,891 @@ tags:
 
 Artifacts are unique custom items with enchantments and/or attribute bonuses. Unlike [[Artisan items]], only one of each artifact exists in the map.
 
+## Absolute Ruin 
+
+|             |                                                          |
+| ----------- | -------------------------------------------------------- |
+| Armor       | 5                                                        |
+| Bonus Stats | -80% Max Health, -0.05 Movement Speed, +15 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | There is no question as to what makes a god, but to the common clay of civilization, what other way to describe the Harbinger of Calamity than a god? To see Her crest over the edge of the realm, knowing that you are now destined. Destined for ruination. |
+| **Obtain** | Located in [[Anyr'Nogur]]. Chest located at **(-3571, 71, 3349)**                                                                                                                                                                                             |
+
+## Aegis of House Anyr
+
+|             |                           |
+| ----------- | ------------------------- |
+| Enchants    | Unbreaking 3              |
+| Bonus Stats | +75% Knockback Resistance |
+
+|            | **Lore and how to Obtain**                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Co-opted for its significance to the Casain, the Ruby of the Dunes is accompanied by the ironic motto of a noble family which ceded its name: "The Lion Never Yields". |
+| **Obtain** | Located in [[Anyr'Nogur]]. Chest located at **(-3468, 141, 2242)**                                                                                                     |
+
+## Air Sailor's Runehat
+
+|             |                             |
+| ----------- | --------------------------- |
+| Armor       | 1                           |
+| Enchants    | Respiration 9, Unbreaking 5 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | In the time of Insohm, these wide-brimmed hats were created to generate pockets of pressurized air around the heads of airship crewmen. This helped deaden engine and wind noise and made breathing in high altitudes easier. |
+| **Obtain** | Located in [[Island of Dusk]]. Chest located at **(-2082, 67, -3319)**                                                                                                                                                        |
+
+## Alviran Signet Shield
+
+|             |                                        |
+| ----------- | -------------------------------------- |
+| Enchants    | Unbreaking 2                           |
+| Bonus Stats | -0.02 Movement Speed, +2 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This shield is emblazoned with the crest of Diore I Alvira, the great Virmari conqueror and Emperor. So long as his standard was in Virsuhl, the Southern Empire of Vir was said to possess coequal authority to Highfall itself. Without Diore and his kin, however, the great city soon fell to opportunists.  |
+| **Obtain** | Located in [[Spearhead Forest]]. Chest located at **(3984, 82, -12)**                                                                                                                                                                                                                                            |
+
+## Ancient Crown
+
+|          |              |
+| -------- | ------------ |
+| Armor    | 3            |
+| Enchants | Unbreaking 7 |
+
+|            | **Lore and how to Obtain**                                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The greatest of the plains civilizations, Drahbes, was an ancient wonder that rose above the city-states of the early Second Avihm. |
+| **Obtain** | Located in [[Gulf of Drehmal]]. Chest located at **(1539, 77, -377)**                                                               |
+
+## Anyr Priest's Tunic
+
+|                 |              |
+| --------------- | ------------ |
+| Armor           | 5            |
+| Armor Toughness | 1            |
+| Enchants        | Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Emperor Anyr, the last ruler of Avsohm, strived to spread his Empire to the furthest reaches of the realm, and for his name to go down in history alongside Drehn Mal'Sohm's. |
+| **Obtain** | Found in a triangular temple within the southeastern plateau of Av'Sal. Chest located at **(1, 116, 1732)**                                                                   |
+
+## AP-357 Excavator
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 4            |
+| Attack Speed  | 1.2          |
+| Enchants      | Efficiency 7 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | One of the very few pickaxes designed to mine rehntite salvaged by Insohm. With Avsohm's mine missing, Master Ultva ordered for every bit of the ancient bedrock beneath Rhaverik to be scoured. |
+| **Obtain** | Found in the mines at [[Rhaverik]] in the [[Heartwood]]. Chest at **(1078, 33, 2143)**                                                                                                           |
+
+## Ardent Dream
+
+|                 |               |
+| --------------- | ------------- |
+| Armor           | 3             |
+| Armor Toughness | 2             |
+| Bonus Stats     | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| **Lore**   | The boots used by a Maelmari vigilante, who fought to protect her people from the Burnt God. |
+| **Obtain** | Located in [[Hellcrags]]. Chest located at **(-4005, 75, 5967)**                             |
+
+## Ardent Force
+
+|                 |               |
+| --------------- | ------------- |
+| Armor           | 6             |
+| Armor Toughness | 2             |
+| Bonus Stats     | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| **Lore**   | The leggings used by a Maelmari vigilante, who fought to protect her people from the Burnt God. |
+| **Obtain** | Located in [[Hellcrags]]. Chest located at **(-4030, 81, 5977)**                                |
+
+## Ardent Hope
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Enchants    | Unbreaking 3                        |
+| Bonus Stats | +6 Max Health, -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                    |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| **Lore**   | The shield used by a Maelmari vigilante, who fought to protect her people from the Burnt God. |
+| **Obtain** | Located in [[Hellcrags]]. Chest located at **(-3943, 52, 6012)**                              |
+
+## Ardent Resolve
+
+|                 |               |
+| --------------- | ------------- |
+| Armor           | 3             |
+| Armor Toughness | 2             |
+| Bonus Stats     | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                    |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| **Lore**   | The helmet used by a Maelmari vigilante, who fought to protect her people from the Burnt God. |
+| **Obtain** | Located in [[Hellcrags]]. Chest located at **(-4019, 53, 5970)**                              |
+
+## Ardent Will
+
+|                 |               |
+| --------------- | ------------- |
+| Armor           | 8             |
+| Armor Toughness | 2             |
+| Bonus Stats     | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| **Lore**   | The chestplate used by a Maelmari vigilante, who fought to protect her people from the Burnt God. |
+| **Obtain** | Located in [[Hellcrags]]. Chest located at **(-3987, 85, 6015)**                                  |
+
+## Arijoor Garments
+
+|          |                                                                              |
+| -------- | ---------------------------------------------------------------------------- |
+| Enchants | Fire Protection 2, Blast Protection 2, Projectile Protection 2, Unbreaking 5 |
+| Armor    | 5                                                                            |
+
+|            | **Lore and how to Obtain**                                                          |
+| ---------- | ----------------------------------------------------------------------------------- |
+| **Lore**   | An article of clothing worn by a Grand Council member of the ancient Arijoor Forks. |
+| **Obtain** | Located in [[Merijool]]. Chest located at **(-843, 105, -1105)**                    |
+
+## Aru'Dahru
+
+|          |                                                                |
+| -------- | -------------------------------------------------------------- |
+| Enchants | Protection 4, Fire Protection 5, Depth Strider 3, Unbreaking 7 |
+| Armor    | 1                                                              |
+
+|            | **Lore and how to Obtain**                                                                    |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| **Lore**   | Powerful boots gifted to members of Dahr's covenant. It roughly translates to 'Grand Waves.'  |
+| **Obtain** | Located in [[Heartwood]]. Chest located at **(60, 57, 3830)**                                 |
+
+## As Foretold
+
+|                 |                                        |
+| --------------- | -------------------------------------- |
+| Armor           | 3                                      |
+| Armor Toughness | 2                                      |
+| Enchants        | Projectile Protection 7, Unbreaking 2  |
+| Bonus Stats     | +0.02 Movement Speed, -3 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | With unprecedented directness, the Star-Rise Drake offers an ornate diadem prominently featuring the Avsohmic Torahn in citrine on a ruby field. |
+| **Obtain** | Located in [[Rihelma]] on [[Lo'Dahr]]. Chest located at **(1125, 83, 1069)**                                                                     |
+
+## Ash-Stained Battle Skirt
+
+|             |                             |
+| ----------- | --------------------------- |
+| Armor       | 3                           |
+| Bonus Stats | +1 Attack Damage, -2 Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                                                 |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Vulteid, the former spiritual heart of the Black Jungle, was home to the Indomitable, a fearsome local militia recognizable for their battle skirts and three straight swords. During the long era of Tidal oppression, many Firteidan children prayed to see those distinctive figures striding out of the lava fields to liberate them from the tyranny. |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(3786, 85, 3927)**                                                                                                                                                                                                                                                                                         |
+
+## Astorahni Ceremonial Plate
+
+|          |                                               |
+| -------- | --------------------------------------------- |
+| Enchants | Protection 1, Fire Protection 6, Unbreaking 6 |
+| Armor    | 6                                             |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                             |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Though their faith grew out of Lai worship In Eastern Merijool the Astorahn tribes eventually came to believe in a different, true source of warmth. This shining plate is emblazoned with a stylized depiction of that heavenly body. |
+| **Obtain** | Located in [[Gulf of Drehmal]]. Chest located at **(-181, 206, -573)**                                                                                                                                                                 |
+
+## AvEP-83
+
+|          |              |
+| -------- | ------------ |
+| Enchants | Protection 5 |
+| Armor    | 6            |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Insohmic scientists under Ultva's leadership tried their best to replicate this lightweight, ultra durable plate discovered in Sal'Mevir, but were not successful. Their impatient commander stormed out, never to be seen again. |
+| **Obtain** | Located in [[Heartwood]]. Chest located at **(1956, 103, 1497)**                                                                                                                                                                  |
+
+## Awe
+
+|               |                      |
+| ------------- | -------------------- |
+| Attack Damage | 10                   |
+| Attack Speed  | 1.0                  |
+| Enchants      | Knockback 4          |
+| Bonus Stats   | +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | One of Amohn Aihura's two famous armaments. The crashing sound of thunder rings out when it meets its unlucky target. Legends speak of Amohn's heroics at the First Battle of Ytaj, when the Palaesidans overcame a Loyalist ambush led by Sereven to take the palace themselves. |
+| **Obtain** | Located in [[Palaesida]] on [[Lo'Dahr]]. Chest located at **(631, 7, 435)**                                                                                                                                                                                                       |
+
+## Axe of Growth
+
+|               |                                     |
+| ------------- | ----------------------------------- |
+| Attack Damage | 7                                   |
+| Attack Speed  | 0.8                                 |
+| Enchants      | Efficiency 3, Unbreaking 3, Mending |
+
+|            | **Lore and how to Obtain**                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------ |
+| **Lore**   | One's growth is paramount to their journey. Let this axe grow alongside you.                           |
+| **Obtain** | Found inside the roof of the Temple of Split Deities in Drabyel. Chest located at **(530, 77, 1858)**  |
+
+## Battlesign
+
+|               |             |
+| ------------- | ----------- |
+| Attack Damage | 8           |
+| Attack Speed  | 1           |
+| Enchants      | Knockback 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                  |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | An extremely unconventional weapon that proved fruitful in spelunking parties. Seen as shameful until one has felt the full force of its broad, flat power. |
+| **Obtain** | In an overgrown house within the [[Heartwood]]. Chest located at **(1644, 83, 1898)**                                                                       |
+
+## Blaze-Blessed Breeches
+
+|                 |                                           |
+| --------------- | ----------------------------------------- |
+| Enchants        | Fire Protection 7, Thorns 2, Unbreaking 2 |
+| Armor           | 6                                         |
+| Armor Toughness | 2                                         |
+| Bonus Stats     | -0.025 Movement Speed, +5 Attack Damage   |
+
+|            | **Lore and how to Obtain**                                                                                                                |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | With unprecedented seriousness, the Brightwyrm offers a metal weave occasionally set alight with tongues of warming, kaleidoscopic flame. |
+| **Obtain** | Located in [[Lai]] on [[Lo'Dahr]]. Chest located at **(1123, 47, -1224)**                                                                 |
+
+## Boltcatcher's Cradle
+
+|             |                                |
+| ----------- | ------------------------------ |
+| Enchants    | Feather Falling 2              |
+| Armor       | 6                              |
+| Bonus Stats | +0.01 Speed, +0.2 Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                               |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Electroplated leggings imbued with the might of the Tempest. Tiny arcs of electricity dance across the wearer's fingers, calling forth unfamiliar memories of an ancient lunar conflict. |
+| **Obtain** | Located in [[Frozen Bite]]. Chest located at **(4665, 154, -3164)**                                                                                                                      |
+
+## Boots of Deigh
+
+|                 |                                                         |
+| --------------- | ------------------------------------------------------- |
+| Enchants        | Unbreaking 4                                            |
+| Armor           | 3                                                       |
+| Armor Toughness | 2                                                       |
+| Bonus Stats     | +10 Max Health, +10% Movement Speed, -90% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Ostracized by Maelmari and Drehmari alike in the west, the Mihkmari had resigned themselves to life on the fringes. Deigh the Dawnstrider, rebel hero and visionary, gathered them together, and led them to a foothold in land Mael could not conquer. The Mihkmari who wears his boots have the loyalty of ten thousand crossbows. |
+| **Obtain** | Located in [[Verdant Labyrinth]]. Chest located at **(3325, 165, 2669)**                                                                                                                                                                                                                                                             |
+
+## Boots of the Honorable
+
+|                 |                   |
+| --------------- | ----------------- |
+| Armor           | 1                 |
+| Enchants        | Unbreaking 3      |
+| Bonus Stats     | +2 Maximum Health |
+
+|            | **Lore and how to Obtain**                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Nemynara's faithful shield, Asrihk Clearbrook, was a mountain of a Drehmari with strong arms and a stronger heart. |
+| **Obtain** | Inside one of the 3 tombs within the Hunter's Crypt. Chest located at **(314, 46, 354)**                           |
+
+## Boots of the Ruthless
+
+|                 |                   |
+| --------------- | ----------------- |
+| Armor           | 1                 |
+| Enchants        | Unbreaking 3      |
+| Bonus Stats     | +0.2 Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Gahwyn, "the Serendipitous", as he wanted to be called, was a rather vain member of the Hunting Party with unprecedented luck only outmatched by his tremendous skill with a bow. |
+| **Obtain** | Inside one of the 3 tombs within the Hunter's Crypt. Chest located at **(314, 46, 354)**                                                                                          |
+
+## Boots of the Scheming
+
+|                 |                     |
+| --------------- | ------------------- |
+| Armor           | 1                   |
+| Enchants        | Unbreaking 3        |
+| Bonus Stats     | +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                            |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | A small Maelmari abandoned as a young child on the streets of Rhaveloth, Ehri Garha was born with nearly nothing. After an altercation with Nemynara herself, she was brought into the Hunting Party. |
+| **Obtain** | Inside one of the 3 tombs within the Hunter's Crypt. Chest located at **(325, 46, 365)**                                                                                                              |
+
+
+## Boots of the Witness
+
+|             |                      |
+| ----------- | -------------------- |
+| Enchants    | Unbreaking 1         |
+| Armor       | 2                    |
+| Bonus Stats | +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | To the King of Nothing, it is all patterns. Only the same people, hopes, triumphs, and mistakes under a new guise, trillions upon trillions of times. But not Drehmal. But not you. |
+| **Obtain** | Located in [[Faehrcyle]]. Chest located at **(1853, 115, -3158)**                                                                                                                   |
+
+## Burial Legwear
+
+|                 |                        |
+| --------------- | ---------------------- |
+| Enchants        | Thorns 3, Unbreaking 5 |
+| Armor           | 6                      |
+| Armor Toughness | 1                      |
+
+|            | **Lore and how to Obtain**                                                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | These pants are adorned with spikes of burnished bronze shaped to look like strips of gauze. A garment fit for the living dead of Arkeje's twilight. |
+| **Obtain** | Located in [[Voynahla]] on [[Lo'Dahr]]. Chest located at **(172, 22, 1164)**                                                                         |
+
+## Casain Theater Mask
+
+|          |                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------ |
+| Enchants | Protection 3, Fire Protection 3, Blast Protection 3, Projectile Protection 3, Unbreaking 6 |
+| Armor    | 2                                                                                          |
+
+|            | **Lore and how to Obtain**                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The Laughing Dragon, who glimpsed the Arc of Twilight, is perhaps the most revered citizens of Sahd. This is one of his more curious possessions. |
+| **Obtain** | Located in [[Sahd]]. Item frame located at **(4484, 157, 5514)**                                                                                  |
+
+## Chronicler's Offering
+
+|             |                                 |
+| ----------- | ------------------------------- |
+| Armor       | 5                               |
+| Bonus Stats | +2 Max Health, +1 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------- |
+| **Lore**   | My gift to you, seeker. Take it! Cherish it, hold it close. Remember it for when I call upon you.  |
+| **Obtain** | Located in [[Anyr'Nogur]]. Item frame located at **(-4589, 71, 2903)**                             |
+
+## Comedically Large Spoon
+
+|               |                             |
+| ------------- | --------------------------- |
+| Attack Damage | 10                          |
+| Attack Speed  | 0.8                         |
+| Enchants      | Efficiency 10, Unbreaking 5 |
+
+|            | **Lore and how to Obtain**                                         |
+| ---------- | ------------------------------------------------------------------ |
+| **Lore**   | An impractically large spoon. There's nothing else to it.          |
+| **Obtain** | Located in [[Frozen Bite]]. Chest located at **(5665, 63, -3680)** |
+
+## Composition No. 9,782,813
+
+|                      |                                  |
+| -------------------- | -------------------------------- |
+| Armor                | 3                                |
+| Armor Toughness      | 2                                |
+| Knockback Resistance | 100%                             |
+| Enchants             | Blast Protection 7, Unbreaking 2 |
+| Bonus Stats          | -30% Attack Speed                |
+
+|            | **Lore and how to Obtain**                                                                                                                                        |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | With unprecedented haste, the Summit-Drake offers a pair of what can only be described as "buttes", made of dramatically carved stone surrounding a durable core. |
+| **Obtain** | Located in [[Nahyn]] on [[Lo'Dahr]]. Chest located at **(530, 123, 15)**                                                                                          |
+
+## Continent Crusher
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 18           |
+| Attack Speed  | 0.5          |
+| Enchants      | Efficiency 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                               |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Widely renowned but lost to time, this uniquely gargantuan pickaxe was wielded by Cehris, deputy to Sereven. A mountainous warrior hailing from a farm in Tharhan, he obtained ascension after besting Taihgel's avatar in an arm-wrestling competition. |
+| **Obtain** | Located in [[Taihgel]] on [[Lo'Dahr]]. Chest located at **(409, 40, -718)**                                                                                                                                                                              |
+
+## Copporius' Scepter
+
+|               |         |
+| ------------- | ------- |
+| Attack Damage | 7       |
+| Attack Speed  | 1.6     |
+| Enchants      | Mending |
+
+|            | **Lore and how to Obtain**                                                          |
+| ---------- | ----------------------------------------------------------------------------------- |
+| **Lore**   | One day, it'll spread to you too... Spread further, beyond horizons, without end... |
+| **Obtain** | Located in [[Loe]] on [[Lo'Dahr]]. Chest located at **(-828, 159, 481)**            |
+
+## Countenance of Virtuo
+
+|          |                                            |
+| -------- | ------------------------------------------ |
+| Armor    | 1                                          |
+| Enchants | Respiration 4, Aqua Affinity, Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Donated to the Kiln by Ekari, a renowned Avsohmic artisan, this gleaming decorative helmet displays a stylized depiction of the Goddess's then perfectly-symmetrical face. |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(3260, 127, 3378)**                                                                                                        |
+
+## Coup de Grace
+
+|          |                            |
+| -------- | -------------------------- |
+| Enchants | Piercing 5, Quick Charge 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                        |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Sometimes, those who attempted to dive between worlds would tragically survive on the rocks below. In those cases, this efficient Casain design proved necessary. |
+| **Obtain** | Located in [[Anyr'Nogur]]. Chest located at **(-4211, 142, 2388)**                                                                                                |
+
+## Crest of Mekta
+
+|               |                                             |
+| ------------- | ------------------------------------------- |
+| Attack Damage | 5                                           |
+| Attack Speed  | 1.6                                         |
+| Enchants      | Knockback 2, Sweeping Edge 5, Unbreaking 10 |
+
+|            | **Lore and how to Obtain**                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | A heavy blade used by the ancient leader of the Mekta tribe, before the first unification at the Arijoor Forks.  |
+| **Obtain** | Located in [[Merijool]]. Chest located at **(-819, 225, -1828)**                                                 |
+
+## Crown of Peace
+
+|                 |     |
+| --------------- | --- |
+| Armor           | 2   |
+| Armor Toughness | 6   |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The Grand Pontiff of Peace was the kindest of the Parish's three leaders, regarded as a natural extension of the Goddess' love. Unfortunately, when she expressed distaste towards the Pontiff of Perfection's aspirations, she was swiftly disposed of.  |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(3888, 52, 3586)**                                                                                                                                                                                        |
+
+## Cryptkeeper's Boots
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 2                 |
+| Bonus Stats | +8% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Recently recovered from the Crypts of Akhlo'Rohma, these Avsohmic guard’s boots were built by Blue Exodus to allow the wearer to perceive, detain, and silence an arcanist before they can utter a single word. |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(1510, 135, -1941)**                                                                                                                                        |
+
+## Cryptkeeper's Chestplate
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 6                 |
+| Bonus Stats | +8% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Recently recovered from the Crypts of Akhlo'Rohma, this Avsohmic guard’s chestplate was built by Blue Exodus to allow the wearer to perceive, detain, and silence an arcanist before they can utter a single word.  |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(1549, 147, -1945)**                                                                                                                                                 |
+
+## Cryptkeeper's Helmet
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 2                 |
+| Bonus Stats | +8% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Recently recovered from the Crypts of Akhlo'Rohma, this Avsohmic guard’s helmet was built by Blue Exodus to allow the wearer to perceive, detain, and silence an arcanist before they can utter a single word.  |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(1513, 160, -1934)**                                                                                                                                             |
+
+## Cryptkeeper's Leggings
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 5                 |
+| Bonus Stats | +8% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Recently recovered from the Crypts of Akhlo'Rohma, these Avsohmic guard’s leggings were built by Blue Exodus to allow the wearer to perceive, detain, and silence an arcanist before they can utter a single word.  |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Dispenser located at **(1524, 151, -1978)**                                                                                                                                             |
+
+## Crystalline Greatshield
+
+|             |                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------ |
+| Enchants    | Unbreaking 2 |
+| Bonus Stats | +0.015 Movement Speed                                                                                  |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This gigantic, but somehow lightweight shield oozes with divine energy. An irresponsible gift to the Frostfang tribes in thanks for helping make a dragon's wildest dreams into reality.  |
+| **Obtain** | Located in [[Faehrcyle]]. Chest located at **(2174, 63, -3448)**                                                                                                                          |
+
+## Damaged Vorpal Greatsword
+
+|               |                                                          |
+| ------------- | -------------------------------------------------------- |
+| Attack Damage | 6                                                        |
+| Attack Speed  | 1.2                                                      |
+| Enchants      | Sharpness 1, Smite 3, Bane of Arthropods 3, Unbreaking 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Half of the sword wielded by Eoglef, a great Frostfang hero. A gleaming gray heirloom that supposedly split from the hero brute's strength when Eoglef decapitated the kraken-serpent Krendahl.  |
+| **Obtain** | Located in [[Highfall Tundra]]. Chest located at **(6171, 83, -1103)**                                                                                                                           |
+
+## Deharian Longsword
+
+|               |                        |
+| ------------- | ---------------------- |
+| Attack Damage | 6                      |
+| Attack Speed  | 1.8                    |
+| Enchants      | Unbreaking 10, Mending |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                     |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The isolated Tharhan kingdom of Dehar once thrived in the heart of Ebonfire, and was well known for their distinctive runic metalworking techniques. After Dehar fell to the Nightwalkers, Deharian steel remained a mystery that even Avsohm couldn't solve.  |
+| **Obtain** | Located in [[Mt. Ebonfire]]. Chest located at **(-3049, 222, 343)**                                                                                                                                                                                            |
+
+## Disciple's Greaves
+
+|                 |                                 |
+| --------------- | ------------------------------- |
+| Armor           | 4                               |
+| Armor Toughness | 1                               |
+| Enchants        | Fire Protection 7, Unbreaking 9 |
+
+|            | **Lore and how to Obtain**                                                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | What crazed lunatic would seek out such beasts? Who would go as far as to call out for the ruinous Mother, knowing that she is gone, away at the end of the world?  |
+| **Obtain** | Located in [[The Carmine]]. Chest located at **(-2250, 7, 5585)**                                                                                                       |
+
+## Dragonslayer Sword
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 6            |
+| Attack Speed  | 1.6          |
+| Enchants      | Unbreaking 4 |
+
+|            | **Lore and how to Obtain**                            |
+| ---------- | ----------------------------------------------------- |
+| **Lore**   | The old, weathered blade of a fabled Tehrmari hunter. |
+| **Obtain** | Located in [[Av'Sal]]. Dropped by a mob.              |
+
+## Drehn's Peace
+
+|               |             |
+| ------------- | ----------- |
+| Attack Damage | 6           |
+| Attack Speed  | 0.8         |
+| Enchants      | Knockback 2 |
+| Bonus Stats   | +2 Armor    |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Drehn Mal’Sohm rose to power through purely defensive tactics, allowing the prosperity of Avsohm to speak for itself while keeping his enemies at arm's length. This classic design is emblematic of his swordless strategy.  |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(1488, 187, -1964)**                                                                                                                                                           |
+
+## Drehuan Macrochisel
+
+|               |            |
+| ------------- | ---------- |
+| Attack Damage | 10         |
+| Attack Speed  | 0.6        |
+| Enchants      | Silk Touch |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The large Drehuan scultor's tool has sat undisturbed within a statue since before the Chosen Kingdom was founded. The statue was refurbished by the order of Emperor Drehn of Avsohm, but its secrets were not divulged until now.  |
+| **Obtain** | Found inside the large Drehuan Statue in [[Palisades Heath]]. Chest located at **(24, 105, 2435)**                                                                                                                                  |
+
+## Drinking Hat
+
+|                 |                                                      |
+| --------------- | ---------------------------------------------------- |
+| Armor           | 3                                                    |
+| Armor Toughness | 1                                                    |
+| Bonus Stats     | +5% Max Health, +5% Movement Speed, +5% Attack Speed |
+
+|            | **Lore and how to Obtain**                                          |
+| ---------- | ------------------------------------------------------------------- |
+| **Lore**   | He was number one!                                                  |
+| **Obtain** | Located in [[Frozen Bite]]. Chest located at **(4447, 148, -3720)** |
+
+## Duspian Chausses
+
+|             |                                 |
+| ----------- | ------------------------------- |
+| Armor       | 5                               |
+| Enchants    | Unbreaking 5                    |
+| Bonus Stats | +6 Health, -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                           |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | A reminder of more peaceful times. After the Battle of Drehmal, Master Vahid attempted to divide the West into provinces under the control of the Council members. After his sudden departure, the Duspian territories in the Veldt slowly fell into internal strife and external conquest from the Burnt Generals.  |
+| **Obtain** | Located in [[Ebony Veldt]]. Chest located at **(-2212, 75, 745)**                                                                                                                                                                                                                                                    |
+
+## Eidolon's Gamble
+
+|             |                                        |
+| ----------- | -------------------------------------- |
+| Armor       | 2                                      |
+| Enchants    | Unbreaking 2                           |
+| Bonus Stats | +3 Attack Damage, -0.02 Movement Speed |
+
+|            | **Lore and how to Obtain**                                           |
+| ---------- | -------------------------------------------------------------------- |
+| **Lore**   | Thousands were chosen. None have succeeded.                          |
+| **Obtain** | Located in [[Nimahj Swamp]]. Chest located at **(-2176, 126, 2326)** |
+
+## Emberhost
+
+|             |                                                         |
+| ----------- | ------------------------------------------------------- |
+| Armor       | 2                                                       |
+| Enchants    | Fire Protection 5                                       |
+| Bonus Stats | +4 Max Health, +10% Attack Damage, -0.04 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | While the Avatars of the Cycle have left the minds of Merijool's peoples, the impact of their conflicts still linger.  |
+| **Obtain** | Located in [[Merijool]]. Chest located at **(-1752, 143, -1647)**                                                      |
+
+## Endless Catch
+
+|             |                                                         |
+| ----------- | ------------------------------------------------------- |
+| Enchants    | Lure 4, Mending                                         |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Larkihn Erigal, a boy of twelve from a Loe-worshipping tribe, brought hope to a starving order of Lai monks after the Frostfang Catastrophe when he caught them three hundred fish in twelve hours. Since then, Okeke has remained a relatively peaceful place.  |
+| **Obtain** | Located in [[Merijool]]. Chest located at **(-1564, 78, -439)**                                                                                                                                                                                                  |
+
+## Equinox
+
+|       |     |
+| ----- | --- |
+| Armor | 6   |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | A dented silver crown of interweaving vines interspersed with fruits and small animals. Though tragically damaged, it exudes a sweet scent and a cool breeze. Once owned by Tehra, first of the Tehrmari. |
+| **Obtain** | Located in [[Moen]] on [[Lo'Dahr]]. Chest located at **(281, 147, -821)**                                                                                                                                 |
+
+## Exquisite Leaf Hat
+
+|       |     |
+| ----- | --- |
+| Armor | 1   |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                     |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The Swamp King originally declared himself "Supreme Grand Over-Ruler-Lord Sultan Viscount Tsar Baron Von Duke of the Greatswamp of Blessed Nimahj�. It was shortened after he realized that the Swampfolk were having immense trouble remembering this title.  |
+| **Obtain** | Located in [[Nimahj Swamp]]. Chest located at **(-2499, 135, 2858)**                                                                                                                                                                                           |
+
+## Flamberge
+
+|               |                                          |
+| ------------- | ---------------------------------------- |
+| Attack Damage | 10                                       |
+| Attack Speed  | 1.6                                      |
+| Enchants      | Knockback 2, Fire Aspect 5, Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | The firstborn daughter of Brulante nobles is traditionally named Flamberge, after the founding ancestor of the family. She was a seasoned pyromancer of much renown, and pioneered a unique family flame. Few alive know the true secret of its power. |
+| **Obtain** | Located in [[Lai]] on [[Lo'Dahr]]. Chest located at **(1273, 193, -1348)**                                                                                                                                                                             |
+
+## Florafilius
+
+|               |                       |
+| ------------- | --------------------- |
+| Attack Damage | 1                     |
+| Attack Speed  | 4                     |
+| Enchants      | Unbreaking 2, Mending |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | An attached note to this sturdy jade hoe reads in delicate looping prose: Blood to sap and lungs to leaves. Rest below our outstretched eaves! Roots from legs and bark from skin. Join the rites of germination!  |
+| **Obtain** | Located in [[Heartwood]]. Chest located at **(2017, 61, 1913)**                                                                                                                                                    |
+
+## Foot Easels
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Armor       | 2                                   |
+| Enchants    | Unbreaking 4                        |
+| Bonus Stats | -10% Max Health, +10% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This unusual work of footwear was created for Kazabar, chieftain of Zarha so that he could be completely surrounded at all times by the art he loved so much. He perished by his own hand after consuming the toxic pigments within a particularly vibrant oil painting.  |
+| **Obtain** | Located in [[Casai]]. Chest located at **(-3037, 63, -735)**                                                                                                                                                                                                              |
+
+## Foreigner's Lodestar
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Enchants    | Unbreaking 10                       |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                  |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | An old fisherman cast his line into the ocean and almost immediately felt a tug like nothing he had ever felt before. It threatened to pull him off of his feet, but he refused to concede. Unmooring, he allowed the beast to pull his craft westward. He never returned.  |
+| **Obtain** | Located in [[Frozen Bite]]. Chest located at **(6603, 83, -2821)**                                                                                                                                                                                                          |
+
+## Form-fitting Leggings
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 2                 |
+| Bonus Stats | +5% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The eloquent and passiontate Dahe Clan were known for their beautiful silken garments that left little to the imagination |
+| **Obtain** | Located in [[Sahd]]. Chest located at **(4518, 64, 5748)**                                                                |
+
+## Form-fitting Tunic
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 3                 |
+| Bonus Stats | +5% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The eloquent and passiontate Dahe Clan were known for their beautiful silken garments that left little to the imagination |
+| **Obtain** | Located in [[Sahd]]. Chest located at **(4518, 64, 5748)**                                                                |
+
+## Fortitude
+
+|             |                                 |
+| ----------- | ------------------------------- |
+| Enchants    | Unbreaking 6, Mending           |
+| Bonus Stats | +8 Max Health, -2 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                                                               |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Invariably accompanying the greatstaff Pristinity, this huge, ornate shield was a hallmark of Virtuo's presence on the battlefield and saved the lives of many. It is rusty from disuse. |
+| **Obtain** | Located in [[Ytaj]] on [[Lo'Dahr]]. Chest located at **(17, 159, -1674)**                                                                                                                |
+
+## Freebooter's Breeches
+
+|                 |                    |
+| --------------- | ------------------ |
+| Armor           | 2                  |
+| Enchants        | Unbreaking 2       |
+| Bonus Stats     | +5% Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | These bright purple pants are made of Casain silk, but have been repaired several times with patches made from other, coarser materials. Vibrant and lawless, Tahva is well-known across the realm as a haven for outcasts and scoundrels. |
+| **Obtain** | Found on a fort on the coast of the 2nd peninsula of Palisades Heath. Chest located at **(249, 124, 2713)**                                                                                                                                |
+
+## Frontier's Edge
+
+|               |                                  |
+| ------------- | -------------------------------- |
+| Attack Damage | 5                                |
+| Attack Speed  | 1.2                              |
+| Enchants      | Efficiency 4, Fortune 1, Mending |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This ceremonial pickaxe was the symbol of the Underliege's rule in the realm of Neverdawn. It is said that Mari's visit so impressed Az'Kaneev the Studious that he granted him this artifact in exchange for telling the court the entire history of the Realm before the Primal Tree's fall. |
+| **Obtain** | Located in [[Ytaj]] on [[Lo'Dahr]]. Chest located at **(-188, 49, -1627)**                                                                                                                                                                                                                     |
+
+## Gehmli's Axe
+
+|               |                      |
+| ------------- | -------------------- |
+| Attack Damage | 19                   |
+| Attack Speed  | 0.3                  |
+| Enchants      | Efficiency 4         |
+| Bonus Stats   | -0.02 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This weapon, fitted with True Ice from a raid on the coven of Loe, was at one time the most legendary weapon in all of Faehrcycle. Sharp as diamond, it could cut through nearly anything in one swipe. |
+| **Obtain** | Located in [[Faehrcycle]]. Chest located at **(2825, 85, -3020)**                                                                                                                                       |
+
+## Glorybringer
+
+|               |                      |
+| ------------- | -------------------- |
+| Attack Damage | 15                   |
+| Attack Speed  | 0.4                  |
+
+|            | **Lore and how to Obtain**                                                   |
+| ---------- | ---------------------------------------------------------------------------- |
+| **Lore**   | The proud and bloodthirsy Osaigah Clan had a simple motto: No pain, no gain. |
+| **Obtain** | Located in [[Sahd]]. Chest located at **(5037, 120, 6345)**                  |
+
+## Goh's Plate
+
+|                 |                              |
+| --------------- | ---------------------------- |
+| Armor           | 5                            |
+| Armor Toughness | 1                            |
+| Enchants        | Unbreaking 6                 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | This advanced Avsohmic plate was clearly well cared-for, but part of the inscription inside is illegible: "Goh......ase use this! It's all I can... to p....... ou when y... et into... hts. I lo...... - Thr..."  |
+| **Obtain** | Located in [[Gulf of Drehmal]]. Chest located at **(315, 68, -127)**                                                                                                                                               |
+
+## Goh's Plate (duplicate)
+
+|                 |                              |
+| --------------- | ---------------------------- |
+| Armor           | 5                            |
+| Armor Toughness | 1                            |
+| Enchants        | Unbreaking 6                 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | This advanced Avsohmic plate was clearly well cared-for, but part of the inscription inside is illegible: "Goh......ase use this! It's all I can... to p....... ou when y... et into... hts. I lo...... - Thr..."  |
+| **Obtain** | Located in [[Gulf of Drehmal]]. Chest located at **(370, 65, -93)**                                                                                                                                                |
+
 ## Gravedigger's Spade
 
 |              |                       |
@@ -25,138 +910,715 @@ Artifacts are unique custom items with enchantments and/or attribute bonuses. Un
 | **Lore**   | A favorite tool of an old grave-tender who buried the caretakers of the Primal Caverns. It is said their belongings would go missing after death. |
 | **Obtain** | In the graveyard tower west of the church along the road between the [[Primal Caverns]] and [[Drabyel]]. Chest located at **(372, 87, 821)**      |
 
-## Axe of Growth
+## Greaves of the Witness
 
-|              |                                                 |
-| ------------ | ----------------------------------------------- |
-| Base Damage  | 7                                               |
-| Attack Speed | 0.8                                             |
-| Enchants     | Efficiency 5, Unbreaking 3, Silk Touch, Mending |
+|             |                      |
+| ----------- | -------------------- |
+| Armor       | 5                    |
+| Enchants    | Unbreaking 1         |
+| Bonus Stats | +0.01 Movement Speed |
 
-|            | **Lore and how to Obtain**                                                                            |
-| ---------- | ----------------------------------------------------------------------------------------------------- |
-| **Lore**   | One's growth is paramount to their journey. Let this axe grow alongside you.                          |
-| **Obtain** | Found inside the roof of the Temple of Split Deities in Drabyel. Chest located at **(530, 77, 1858)** |
+|            | **Lore and how to Obtain**                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | If one were to witness a power so great it tore through gods and empires with ease, what else could one do than revere it? |
+| **Obtain** | Located in [[Faehrcycle]]. Chest located at **(4397, 141, -3886)**                                                               |
 
-## Boots of the Honorable
+## Gumption
+
+|              |         |
+| ------------ | ------- |
+| Base Damage  | 9       |
+| Attack Speed | 1.2     |
+| Enchants     | Mending |
+
+|            | **Lore and how to Obtain**                                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The twin blades of this war axe glimmer gleefully when you grip its comfortable handle. When you swing it, it seems to subtly change its angle of attack to inflict maximum damage |
+| **Obtain** | Located in [[North Tharxax]]. Chest located at **(-1048, 71, 2503)**                                                                                                               |
+
+## Gutripper Backblade
+
+|              |                     |
+| ------------ | ------------------- |
+| Base Damage  | 34                  |
+| Attack Speed | 0.1                 |
+| Enchants     | Sweeping Edge 2     |
+| Bonus Stats  | -0.1 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                          |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| **Lore**   | A rough, thick, and heavy blade; akin to large chunk of raw ore. It could hardly be called a sword. |
+| **Obtain** | Located in [[South Tharxax]]. Chest located at **(-2326, 74, 4393)**                                |
+
+## Harbormaster's Cap
+
+|             |                                                       |
+| ----------- | ----------------------------------------------------- |
+| Armor       | 1                                                     |
+| Bonus Stats | +2 Max Health, +0.01 Movement Speed, +1 Attack Damage |
+
+|              | **Lore and how to Obtain**                                                                                                                                                                                       |
+| ----------   | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**     | An old, faded cap that nonetheless bears the insignia of a full Avsohmic admiral. Nearby paperwork suggests that whoever wore it must have overseen countless secret voyages to the Aphelion, Avsohm's flagship. |
+| **Obtain**   | Located in [[Anyr'Nogur]]. Chest located at **(-3979, 112, 1626)**                                                                                                                                               |
+
+## Harvester's Overalls
+
+|             |                |
+| ----------- | -------------- |
+| Armor       | 1              |
+| Enchants    | Unbreaking 10  |
+| Bonus Stats | +12 Max Health |
+
+|            | **Lore and how to Obtain**                                                                                           |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | These well-worn leather overalls have not fallen apart despite over ten centuries of constant use by field laborers. |
+| **Obtain** | Located in [[Noha]] on [[Lo'Dahr]]. Chest located at **(989, 59, -200)**                                             |
+
+## Heart of Glass
+
+|             |                                                          |
+| ----------- | -------------------------------------------------------- |
+| Armor       | 5                                                        |
+| Bonus Stats | -10 Max Health, +0.015 Movement Speed, +3 Attaack Damage |
+
+|            | **Lore and how to Obtain**                                               |
+| ---------- | ------------------------------------------------------------------------ |
+| **Lore**   | The King of Glass speaks to no one, for his death would come too easily. |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(4088, 228, 3834)**              |
+
+## Her Truth
+
+|             |                                                         |
+| ----------- | ------------------------------------------------------- |
+| Armor       | 2                                                       |
+| Encahnts    | Unbreaking 2                                            |
+| Bonus Stats | -8 Max Health, +0.015 Movement Speed, +2 Attaack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | There exists a prophet who lives on the moon out of sight. She sees visitations from all, even those beyond, for her visions are boundless. |
+| **Obtain** | Located in [[Veruhkt Plateau]]. Chest located at **(4285, 123, -1719)**                                                                                |
+
+## Ignus Scythe
+
+|               |                                                         |
+| ------------- | ------------------------------------------------------- |
+| Attack Damage | 8                                                       |
+| Attack Speed  | 2                                                       |
+| Enchants      | Fire Aspect 3                                           |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                    |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This well-balanced tool gleams with the ever-shifting luster of magma itself. Sacred to Taihgel worshippers, it looks like it would be equally effective at dividing earth and rending flesh. |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(4546, 43, 3731)**                                                                                                                            |
+
+## Iker Harvester
+
+|               |                          |
+| ------------- | ------------------------ |
+| Attack Damage | 10                       |
+| Attack Speed  | 2                        |
+| Enchants      | Looting 1, Efficiency 10 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                  |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | A mysterious object from impossibly far away. Glimpses from Rihelma's visions sometimes find their way into reality within the Augural Tangle. This recently-freed tool was apparently used for digging and exsanguination. |
+| **Obtain** | Located in [[Aldragekar]] on [[Lo'Dahr]]. Chest located at **(1022, 33, 1134)**                                                                                                                                             |
+
+## Imitation Talon Uniform
+
+|          |                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------- |
+| Armor    | 6                                                                                           |
+| Enchants | Protection 2, Fire Protection 2, Blast Protection 2, Projectile Protection 2, Unbreaking 4, |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | At the height of Sereven's Coup, the lives of any Ro'Tehrmari leaders were forfeit the moment they were seen by a Talon officer. A small contingent of young Roheians under the command of Orrah Din planned a daring counteroffensive while hiding in the Sohac Crags, but the Moonsworn acted first. |
+| **Obtain** | Located in [[Voynahla]] on [[Lo'Dahr]]. Chest located at **(541, 34, 1166)**                                                                                                                                                                                                                           |
+
+## Indomitable
+
+|             |                                                       |
+| ----------- | ----------------------------------------------------- |
+| Armor       | 7                                                     |
+| Bonus Stats | -4 Max Health, -0.01 Movement Speed, +4 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | If you hold a hand to its scarred, lukewarm breast, you can feel the slow rumbling beat of a heart that refuses to die. |
+| **Obtain** | Located in [[Faehrcycle]]. Chest located at **(3373, 70, -4032)**                                                             |
+
+## Inspector's Crossbow
+
+|             |                                                       |
+| ----------- | ----------------------------------------------------- |
+| Enchants    | Quick Charge 2                                        |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Between its coastal location and favorable but strict trade laws, Sal'Lohd was once the premier port in Casai. The Lohdan Port Authority made sure that the markets were fair for all participants by any means necessary. |
+| **Obtain** | Located in [[Casai]]. Chest located at **(-2325, 88, -1198)**                                                                                                                                                              |
+
+## Insulated Mask
+
+|                 |                      |
+| --------------- | -------------------- |
+| Armor           | 5                    |
+| Armor Toughness | 2                    |
+| Enchants        | Unbreaking 5         |
+| Bonus Stats     | -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                           |
+| ---------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Two zippers break the uniformity of this padded mask's exterior, enough for one eye to see and the mouth to consume. |
+| **Obtain** | Located in [[Spearhead Forest]]. Chest located at **(3124, 25, 1270)**                                                           |
+
+## Insurance
+
+|             |                 |
+| ----------- | --------------- |
+| Enchants    | Infinity        |
+| Bonus Stats | +10% Max Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The cautious and devout Zedoh Clan made sure that there was always a contingency plan. Unfortunately, these seasoned survivors could not withstand the ravages of time. |
+| **Obtain** | Located in [[Sahd]]. Chest located at **(5191, 115, 5574)**                                                                                                             |
+
+## Involuntary Ranged Injection Mechanism
+
+|             |                         |
+| ----------- | ----------------------- |
+| Enchants    | Power 2, Punch 2, Flame |
+| Bonus Stats | +2 Armor                |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This device was designed by Sybh, a Ro'Tehrmari inductee into the Coven of Alchemists in Maen's Domain. It was used with great success to procure experimental subjects for a time, but was eventually discontinued when one dart missed its mark and a very angry Talon officer found hers. |
+| **Obtain** | Located in [[Maen]] on [[Lo'Dahr]]. Chest located at **(-98, 82, -288)**                                                                                                                                                                                                                     |
+
+## Jack's Jacket
+
+|             |                                  |
+| ----------- | -------------------------------- |
+| Armor       | 3                                |
+| Enchants    | Thorns 4, Unbreaking 10, Mending |
+
+|            | **Lore and how to Obtain**                                                                                  |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This extremely cool jacket is emblazoned with patches from youth counterculture bands throughout the realm. |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(4331, 134, 4409)**                                         |
+
+## Keelbreaker
+
+|               |               |
+| ------------- | ------------- |
+| Attack Damage | 9             |
+| Attack Speed  | 1             |
+| Bonus Stats   | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Along with the military might of Emperor Diore I and his Vanguard, the other secret to Vir's steely grip over the East was the construction of sturdy stone forts in each province where the people could take shelter from attackers. This heavy crushing axe was used to cripple enemy ships when their occupants attempted to lay siege. |
+| **Obtain** | Located in [[Highfall Tundra]]. Chest located at **(5269, 122, -2086)**                                                                                                                                                                                                                                                                                |
+
+## Leliouria
+
+|                |                |
+| -------------- | -------------- |
+| *garbled text* | *garbled text* |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | An ancient memento recovered by Red Dawn's Leader *garbled text* during a far-flung expedition. It appears to be *garbled text* ever-shifting, never settling down on one form, always *garbled text* physical but never something you recognize. *garbled text* |
+| **Obtain** | Located in [[Red Dawn]]. Chest located at **(3194, 88, -556)**                                                                                                                                                                                                   |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-270, 8, 438)**                                                                                                                                                                                                                                                |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-198, 43, 236)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-130, 47, 277)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-330, 21, 280)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-260, 28, 304)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-195, 51, 347)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-470, 29, 492)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-480, 53, 478)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-467, 76, 470)**                                                                                                                                                                                                                                               |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-450, 106, 497)**                                                                                                                                                                                                                                              |
+
+## Lesser Scalepiercer
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 8         |
+| Attack Speed  | 0.9       |
+| Enchants      | Loyalty 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This homemade trident was made by an unlucky treasure hunter. Stories speak of a morning when Dahr loudly announced a challenge to the entire moon. "Let it be heard: in a sea cave lies a trident of great strength and value. If you seek it and defeat all foes who lie within, you shall earn the weapon's might." |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-451, 106, 499)**                                                                                                                                                                                                                                              |
+
+## Liberator
+
+|          |                    |
+| -------- | ------------------ |
+| Enchants | Mending, Multishot |
+
+|            | **Lore and how to Obtain**                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The polished azurwood hilt of this crossbow is adorned with a stylized depiction of a school of glowing green fish stripping a dragon's flesh away into bone. |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-417, 18, 906)**                                                                                      |
+
+## Lodebearer
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Armor       | 6                                   |
+| Enchants    | Blast Protection 2                  |
+| Bonus Stats | +6 Max Health, -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Ariell Havehz, the young but ingenious current Chieftan of Athrah, was the first to think about mining the Gorahn Buttes for gold. To carry all the ore, this sleeved vest is outfitted with dozens of large, sturdy pockets. |
+| **Obtain** | Located in [[Casai]]. Chest located at **(-2550, 100, -1562)**                                                                                                                                                                 |
+
+## Loe'Othrah
+
+|               |            |
+| ------------- | ---------- |
+| Attack Damage | 5          |
+| Attack Speed  | 1.6        |
+| Enchants      | Silk Touch |
+
+|            | **Lore and how to Obtain**                                                |
+| ---------- | ------------------------------------------------------------------------- |
+| **Lore**   | Loe, Avatar of Ash, created the truest of ice to be used by her disciples |
+| **Obtain** | Located in [[Merijool]]. Chest located at **(-656, 97, -1729)**               |
+
+## Lomach's Warplate
+
+|             |                |
+| ----------- | -------------- |
+| Bonus Stats | +14 Max Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Born an especially weak Mikhmari, Lomach'sparents decided to volunteer him for Red Dawn experimentation at the Burnt Palace. Reborn in a new form through innovative necromancy, he relearned speech and later carried the great hero Deigh as he traveled the realm to unite their people. |
+| **Obtain** | Located in [[Ebony Veldt]]. Chest located at **(-1174, 70, 802)**                                                                                                                                                                                                                                  |
+
+## Lookout Legwear
 
 |                 |                   |
 | --------------- | ----------------- |
-| Armor           | 1                 |
-| Armor Toughness | 0                 |
-| Enchants        | Unbreaking 3      |
-| Bonus Stats     | +2 Maximum Health |
+| Armor           | 5                 |
+| Armor Toughness | 1                 |
+| Enchants        | Feather Falling 3 |
 
-|            | **Lore and how to Obtain**                                                                                         |
-| ---------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Lore**   | Nemynara's faithful shield, Asrihk Clearbrook, was a mountain of a Drehmari with strong arms and a stronger heart. |
-| **Obtain** | Inside one of the 3 tombs within the Hunter's Crypt. Chest located at **(314, 46, 354)**                           |
+|            | **Lore and how to Obtain**                                                                                                                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Named for the phrase uttered by bystanders on each of the four occasions that a guard fell off an unsafe bridge or balcony into the canyon below. Now considrred cursed, but probably wearable. |
+| **Obtain** | Located in [[The Carmine]]. Chest located at **(-2079, 154, 5977)**                                                                                                                                    |
 
-## Boots of the Scheming
+## Lorahn Sacrificial Blade
 
-|                 |                     |
-| --------------- | ------------------- |
-| Armor           | 1                   |
-| Armor Toughness | 0                   |
-| Enchants        | Unbreaking 3        |
-| Bonus Stats     | +10% Movement Speed |
+|               |         |
+| ------------- | ------- |
+| Attack Damage | 5       |
+| Attack Speed  | 1.5     |
+| Enchants      | Smite 6 |
 
-|            | **Lore and how to Obtain**                                                                                                                                                                            |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lore**   | A small Maelmari abandoned as a young child on the streets of Rhaveloth, Ehri Garha was born with nearly nothing. After an altercation with Nemynara herself, she was brought into the Hunting Party. |
-| **Obtain** | Inside one of the 3 tombs within the Hunter's Crypt. Chest located at **(325, 46, 365)**                                                                                                              |
+|            | **Lore and how to Obtain**                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | A jagged stone dagger, made specifically for sacrifices. It is said to have been an integral part of a necrotic engine's operations. |
+| **Obtain** | Located in [[Lorahn'Kahl]]. Chest located at **(-108, 67, 4802)**                                                                           |
 
-## Boots of the Ruthless
+## Luminous Diadem
+
+|                 |                                       |
+| --------------- | ------------------------------------- |
+| Armor           | 2                                     |
+| Armor Toughness | 4                                     |
+| Enchants        | Projectile Protection 4, Unbreaking 6 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The Duke of Greyspire kept this ornate crystalline accessory despite the sickening atrocities of its previous wearer. Its pleasing golden gleam embodies the vibrance of a promise never kept. |
+| **Obtain** | Located in [[Loe]] on [[Lo'Dahr]]. Chest located at **(-819, 196, 518)**                                                                                                                       |
+
+## Magnetic Acceleration Combat Crossbow
+
+|          |              |
+| -------- | ------------ |
+| Enchants | Unbreaking 8 |
+
+|            | **Lore and how to Obtain**                                   |
+| ---------- | ------------------------------------------------------------ |
+| **Lore**   | Designed by Blue Exodus's Military Technology Division (MTD), this lethal anti-infantry crossbow was a relatively lightweight and inexpensive alternative to the energy rifle. Produced and tested at the Foundry, its lethality is only 18.7% less for a fraction of the runes. |
+| **Obtain** | Located in [[Mt. Ebonfire]]. Chest located at **(-3174, 122, 942)**  |
+
+## Malevolentius
+
+|               |                                     |
+| ------------- | ----------------------------------- |
+| Attack Damage | 10                                  |
+| Attack Speed  | 0.8                                 |
+| Enchants      | Fire Aspect 1                       |
+| Bonus Stats   | +4 Max Health, -0.02 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | A woman's carefully crafted gift to the lord of desolation. Despite its great craftsmanship, it was met with no embrace, for Mael had been forsaken once before. |
+| **Obtain** | Located in [[South Heartwood]]. Chest located at **(946, 151, 5052)**                                                                                                       |
+
+## Mantle of the Calamitous
+
+|             |                                                         |
+| ----------- | ------------------------------------------------------- |
+| Armor       | 5                                                       |
+| Enchants    | Unbreaking 1                                            |
+| Bonus Stats | -15% Max Health, +15% Movement Speed, -15% Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The raw, absolute power of a Skullbeast can drive one to fiendish hysterics in pursuit of further strength. This toothy mantle was an early project of one such pursuer, but was cast aside in favor of armor featuring the ribs of a Skullbeast. Now fully gripped by madness, they have completed their magnum opus. |
+| **Obtain** | Located in [[Ebony Veldt]]. Chest located at **(-2145, 67, 412)**                                                                                                                                                                                                                                                             |
+
+## Marred Masterwork
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 4         |
+| Attack Speed  | 1.2       |
+| Enchants      | Fortune 1 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Once a truly remarkable tool forged from Deharian steel, this pickaxe was worn down by thousands of careless strokes from the hands of the Sacrificed. The Tri-Moon Theocracy met its downfall when its leaders failed to account for the effects of soul depletion after every loop. |
+| **Obtain** | Located in [[Lorahn'Kahl]]. Chest located at **(-1112, 102, 5203)**                                                                                                                                                                                                                   |
+
+## Maw
+
+|             |                                                        |
+| ----------- | ------------------------------------------------------ |
+| Armor       | 1                                                      |
+| Enchants    | Thorns 4                                               |
+| Bonus Stats | -10 Max Health, -0.05 Movement Speed, -5 Attack Damage |
+
+|            | **Lore and how to Obtain**                                                      |
+| ---------- | ------------------------------------------------------------------------------- |
+| **Lore**   | As said by the eidolic whispers, "HERE YOU SHALL DREAM OF TEETH AND ONLY TEETH" |
+| **Obtain** | Located in [[Highfall Tundra]]. Chest located at **(4464, 42, -2110)**                     |
+
+## Mirage
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 14           |
+| Attack Speed  | 1.6          |
+| Enchants      | Sharpness 10 |
+
+|            | **Lore and how to Obtain**                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| **Lore**   | Like the brooding and vain Water Wynm themselves, Drahroehl's blessings are often double-edged. |
+| **Obtain** | Located in [[Anyr'Nogur]]. Rewarded upon solving the Temple of Dahroehl's puzzle. |
+
+## Mirrorhelm of Stars
+
+|                 |                                     |
+| --------------- | ----------------------------------- |
+| Armor           | 3                                   |
+| Armor Toughness | 2                                   |
+| Enchants        | Unbreaking 6                        |
+| Bonus Stats     | +6 Max Health, -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This helmet was meticulously crafted out of dozens of pieces of finely polished silver, creating a dazzling reflective surface. The monks of the Starrise Bastion claim that it blocks otherworldly interference which, when combined with heightened focus, could allow one to directly query Rihelma. |
+| **Obtain** | Located in [[Island of Dawn]]. Chest located at **(-913, 182, -4146)**                                                                                                                                                                                                                                            |
+
+## Mud-Caked Chainmail
 
 |                 |                   |
 | --------------- | ----------------- |
-| Armor           | 1                 |
-| Armor Toughness | 0                 |
-| Enchants        | Unbreaking 3      |
-| Bonus Stats     | +10% Attack Speed |
+| Armor           | 6                 |
+| Armor Toughness | 2                 |
+| Enchants        | Fire Protection 3 |
 
-|            | **Lore and how to Obtain**                                                                                                                                                        |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lore**   | Gahwyn, "the Serendipitous", as he wanted to be called, was a rather vain member of the Hunting Party with unprecedented luck only outmatched by his tremendous skill with a bow. |
-| **Obtain** | Inside one of the 3 tombs within the Hunter's Crypt. Chest located at **(314, 46, 354)**                                                                                          |
+|            | **Lore and how to Obtain**                                                                                                                                                                                  |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The letters "S" and "D" are inscribed on this neglected piece, the only sign of what happened to a foolhardy Tharxacian lady who would not bend a knee to Maelihs and so built a castle in a swamp instead. |
+| **Obtain** | Located in [[Nihmaj Swamp]]. Chest located at **(-2261, 93, 2517)**                                                                                                                                                 |
 
-## Anyr Preist's Tunic
+## Mystic Vow
 
-|                 |              |
-| --------------- | ------------ |
-| Armor           | 5            |
-| Armor Toughness | 1            |
-| Enchants        | Unbreaking 3 |
+|          |                         |
+| -------- | ----------------------- |
+| Armor    | 2                       |
+| Enchants | Projectile Protection 7 |
 
-|            | **Lore and how to Obtain**                                                                                                                                                    |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lore**   | Emperor Anyr, the last ruler of Avsohm, strived to spread his empire to the furthest reaches of the realm, and for his name to go down in history alongside Drehn Mal'Sohm's. |
-| **Obtain** | Found in a triangular temple within the southeastern plateau of Av'Sal. Chest located at **(1, 117, 1732)**                                                                   |
+|            | **Lore and how to Obtain**                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Shortly after the Frostfang Catastrophe, a strange mystic individual hid beneath Ihted, pursued by the fangs of drakes. |
+| **Obtain** | Located in [[Capital Valley]]. Chest located at **(1084, 58, 1141)**                                                              |
 
-## Battlesign
+## Nautical Boots
 
-|              |             |
-| ------------ | ----------- |
-| Base Damage  | 8           |
-| Attack Speed | 1           |
-| Enchants     | Knockback 3 |
+|                 |                                               |
+| --------------- | --------------------------------------------- |
+| Armor           | 3                                             |
+| Armor Toughness | 2                                             |
+| Enchants        | Respiration 2, Aqua Affinity, Depth Strider 2 |
 
-|                                       | **Lore and how to Obtain**                                                                                                                                  |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lore**                              | An extremely unconventional weapon that proved fruitful in spelunking parties. Seen as shameful until one has felt the full force of its broad, flat power. |
-| **Obtain**                            | In an overgrown house within the [[Heartwood]]. Chest located at **(1644, 83, 1898)**                                                                       |
+|            | **Lore and how to Obtain**                                                                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | An ancient pair of heeled boots in excellent condition. Belong to a solitary, melancholy hermit. Adorned with deictions of warships, waves, and dramatic clouds at sea. |
+| **Obtain** | Located in [[Grand Pike Canyon]]. Chest located at **(3775, 93, -393)**                                                                                                              |
 
-## AP-357 Excavator
+## Nullblade
 
-|              |              |
-| ------------ | ------------ |
-| Base Damage  | 4            |
-| Attack Speed | 1.2          |
-| Enchants     | Efficiency 7 |
+|               |             |
+| ------------- | ----------- |
+| Attack Damage | 7           |
+| Attack Speed  | 1.6         |
+| Bonus Stats   | Unbreakable |
 
-|            | **Lore and how to Obtain**                                                                                                                                                                       |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Lore**   | One of the very few pickaxes designed to mine rehntite salvaged by Insohm. With Avsohm's mine missing, Master Ultva ordered for every bit of the ancient bedrock beneath Rhaverik to be scoured. |
-| **Obtain** | Found in the mines at [[Rhaverik]] in the [[Heartwood]]. Chest at **(1078, 33, 2143)**                                                                                                           |
+|            | **Lore and how to Obtain**                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Made from an incredible durable material discovered in small quantities at Sal'Mevir. The Insohmic Coven of Potentia used these weapons to control their Chosen. |
+| **Obtain** | Located in the Insohmic Coven of Potentia on the east coast of the islands to the east of Mossfield. Chest located at **(6035, 61, 1515)**                       |
 
-## Temporal Bow
+## Ostracizing Belt
 
-|             |          |
-| ----------- | -------- |
-| Bonus Stats | N/A      |
-| Enchants    | Infinity |
+|                 |                                             |
+| --------------- | ------------------------------------------- |
+| Armor           | 5                                           |
+| Armor Toughness | 4                                           |
+| Enchants        | Blast Protection 2, Projectile Protection 2 |
 
-|            | **Lore and how to Obtain**                                                                                                     |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **Lore**   | Avsohm advanced at such a rapid pace, it would be some time before that technology found its way into the hands of its people. |
-| **Obtain** | Inside an avsohmic-looking tower in northwestern [[Purity Peaks]]. Chest located at **(1747, 186, 109)**                       |
+|            | **Lore and how to Obtain**                                                                                                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This bulky belt is constructed out of two interweaving leather straps, each carved with complex runes. One of five worn by members of Sereven's Claw, whose collective power necessitated the Moonsworn's creation. |
+| **Obtain** | Located in [[Ytaj]] on [[Lo'Dahr]]. Chest located at **(51, 29, -1572)**                                                                                                                                            |
 
-## Drehuan Macrochisel
+## Outlaw's Boots
 
-|              |            |
-| ------------ | ---------- |
-| Base Damage  | 10         |
-| Attack Speed | 0.6        |
-| Enchants     | Silk Touch |
+|             |                                      |
+| ----------- | ------------------------------------ |
+| Armor       | 1                                    |
+| Bonus Stats | -2 Max Health, +0.015 Movement Speed |
 
-|            | **Lore and how to Obtain**                                                                                                                                                                                                          |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lore**   | The large Drehuan sculptor's tool has sat undisturbed within a statue since before the Chosen Kingdom was founded. The statue was refurbished by the order of Emperor Drehn of Avsohm, but its secrets were not divulged until now. |
-| **Obtain** | Found inside the large Drehuan Statue in [[Palisades Heath]]. Chest located at **(24, 105, 2435)**                                                                                                                                  |
+|            | **Lore and how to Obtain**                                 |
+| ---------- | ---------------------------------------------------------- |
+| **Lore**   | Always on the run. Always got a plan.                      |
+| **Obtain** | Located in [[South Heartwood]]. Chest located at **(1436, 62, 3839)** |
 
-## Freebooter's Breeches
+## Oversized Scalpel
 
-|                 |                    |
-| --------------- | ------------------ |
-| Armor           | 2                  |
-| Armor Toughness | 0                  |
-| Enchants        | Unbreaking 2       |
-| Bonus Stats     | +5% Movement Speed |
+|               |     |
+| ------------- | --- |
+| Attack Damage | 4   |
+| Attack Speed  | 3   |
 
-|            | **Lore and how to Obtain**                                                                                                                                                                                                                 |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Lore**   | These bright purple pants are made of Casain silk, but have been repaired several times with patches made from other, coarser materials. Vibrant and lawless, Tahva is well-known across the realm as a haven for outcasts and scoundrels. |
-| **Obtain** | Found on a fort on the coast of the 2nd peninsula of Palisades Heath. Chest located at **(249, 124, 2713)**                                                                                                                                |
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                              |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | While at first conventional surgical scalpals were used for cutting flesh and inserting powdered bluegrape after the Provider arrived, increasingly grapemad members of the court began using larger implements to pack more of the seeds within their body cavities. Perhaps, then, they could see the euphoric visions one more time. |
+| **Obtain** | Located under Loraga Keep in [[South Tharxax]] on the path traveling north from Tharxax City. Chest located at **(-1765, 138, 3036)**                                                                                                                                                                                                                                                                            |
+
+## Pearlessence
+
+|                 |                                  |
+| --------------- | -------------------------------- |
+| Enchants        | Unbreaking 2                     |
+| Armor           | 8                                |
+| Armor Toughness | 2                                |
+| Bonus Stats     | -8 Max Health, +20% Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                           |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | With unprecedented humility, the Abyssal Elder offers a strangely smooth carapace which refracts into streaks of brilliant color when illuminated by a bright light. |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-197, 18, 1177)**                                                                                            |
+
+## Pheonixfeather Cloak
+
+|                      |               |
+| -------------------- | ------------- |
+| Armor                | 7             |
+| Armor Toughness      | 3             |
+| Knockback Resistance | 60%           |
+| Enchants             | Unbreaking 2  |
+| Bonus Stats          | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                       |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Rihanar, the third-largest Tehrmari habitiation prior to the Schism, remained an isolated hub for craftspeople until every soul within disappeared one day. This thermal outerwear is perfect for travel in cold, windy regions. |
+| **Obtain** | Located in [[Rihelma]] on [[Lo'Dahr]]. Chest located at **(842, 237, 591)**                                                                                                                                                      |
+
+## Plaguebearer's Longbow
+
+|             |                                      |
+| ----------- | ------------------------------------ |
+| Bonus Stats | -6 Max Health, +0.015 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | When a green-skinned Drehmari washed up on the shores of isolated Sevick, the villagers were cast into agonizing fear. After disarming, imprisoning, and later stoning the Gozaki trader, they each became convinced they were dying of pestilence. Though three perished from crude attempts at surgery, the rest fled and never returned. |
+| **Obtain** | Located in Sevick on a small island to the east of [[Spearhead Forest]]. Chest located at **(5039, 97, 1070)**                                                                                                                                                                                                                                                                                  |
+
+## Prismatic Helmet
+
+|             |                                                      |
+| ----------- | ---------------------------------------------------- |
+| Bonus Stats | -4 Max Health, +0.1 Attack Speed, +10% Attack Damage |
+
+|            | **Lore and how to Obtain**                                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This helmet was porn by an individual who believed they had a seat on the Prismatic Council. Foolish.                                          |
+| **Obtain** | Located atop a blue and prismarine plateau on the coast between [[Lorahn'Kahl]] and [[Palisade's Heath]]. Chest located at **(18, 208, 4303)** |
+|            |                                                                                                                                                |
+
+## Prototype Probe Launcher
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Bonus Stats | +4 Max Health, -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The exhibit reads: "We know from Sal'Mevir that Avsohm had probes which could fly autonomously. This appears to be an early experiment wherin the user could fire a small probe to perform limited surveillance and then recall it via runic magic that has been lost to time." |
+| **Obtain** | Located within the Timberhearth Observatory & Museum in [[Spearhead Forest]]. Chest located at **(4141, 135, 280)**                                                                                                                                                                                                          |
+
+## Quailfeather Helm
+
+|             |                   |
+| ----------- | ----------------- |
+| Armor       | 1                 |
+| Enchants    | Unbreaking 2      |
+| Bonus Stats | +10% Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | An ornamental helm worn by Narid of Azaim. The Casian residents of Azaim were cursed by fate, as the home they chose to be free from Maelih's advances in the West was the very site of Gendrik's Incursion. With the Council deadlocked, Maelmari made short work of the Akhlo'Rohman country-side. |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(2751, 134, -1921)**                                                                                                                                                                                                                                  |
 
 ## Quartzite Blade
 
@@ -170,3 +1632,519 @@ Artifacts are unique custom items with enchantments and/or attribute bonuses. Un
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Lore**   | This wickedly sharp rapier was wielded by the Whispers, elite guards of the Insohmic Coalition Grand Council. After the departure of Master Vahid, they abandoned their former masters to become a guild of deadly assassins. |
 | **Obtain** | Found in the sunken ship on the shore of [[The Carmine]]. Chest located at **(-3056, 62, 3952)**                                                                                                                              |
+
+## Rhalon's Chestplate
+
+|     |     |
+| --- | --- |
+
+|            | **Lore and how to Obtain** |
+| ---------- | -------------------------- |
+| **Lore**   |                            |
+| **Obtain** |                            |
+
+## Rocky Helmet
+
+|          |                        |
+| -------- | ---------------------- |
+| Armor    | 2                      |
+| Enchants | Thorns 4, Unbreaking 6 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | This helmet shines a brilliant yellow and green, with rocky protrusions covering its surface. It was crafted by the high priest of Xorhuul in an early, unsuccessful attempt to commune with Koh |
+| **Obtain** | Located in [[Island of Dawn]]. Chest located at **(-1263, 46, -4060)**                                                                                                                                     |
+
+## Rootfinder
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 6            |
+| Attack Speed  | 1            |
+| Enchants      | Unbreaking 4 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                              |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Craving the savory spice of Paroto roots, Seylon Klemelli first journeyed across Drehmal to the wild Ebony Veldt forty years ago. Since then, without missing a single year, she has returned every year to harvest more. This perfectly balanced shovel has a runic sensor which detects the telltale soil acidity of a tuber cluster. |
+| **Obtain** | Located in [[Ebony Veldt]]. Chest located at **(-2339, 107, 1484)**                                                                                                                                                                                                                                                                            |
+
+## Runecatcher
+
+|          |                           |
+| -------- | ------------------------- |
+| Enchants | Luck of the Sea 5, Lure 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Not just any rod could be used to mollify a mighty glyphtrout or a sigiled catfish in its prime. Although they were once plentiful in Lake Khanak, those that remain are twisted and thin, capable of being caught with one's bare hands. |
+| **Obtain** | Located in [[Khive]] on [[Lo'Dahr]]. Chest located at **(-909, 76, -142)**                                                                                                                                                                |
+
+## Rusted Sabatons
+
+|             |                                                                          |
+| ----------- | ------------------------------------------------------------------------ |
+| Armor       | 3                                                                        |
+| Enchants    | Unbreaking 5                                                             |
+| Bonus Stats | -2 Max Health, -0.01 Movement Speed, +1 Attack Damage, +0.2 Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | These incredible durable boots are all that are left of the Soldier Nemynar, legendary leader of the Hunting Party who perished victorious in his quest for vengeance. |
+| **Obtain** | Located in [[North Heartwood]]. Chest located at **(1073, 79, 2934)**                                                                                                             |
+
+## S21A-"Dragon"
+
+|             |               |
+| ----------- | ------------- |
+| Enchants    | Unbreaking 8  |
+| Bonus Stats | +4 Max Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                                       |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This prototype was an early attempt to create means of deflecting blasts of raw primal energy. It was specifically built for the frontline soldiers and infantry of Blue Exodus. |
+| **Obtain** | Located in [[Blue Exodus]]. Chest located at **(-2641, 32, 2126)**                                                                                                               |
+
+## S21B-"Spider"
+
+|             |                      |
+| ----------- | -------------------- |
+| Enchants    | Unbreaking 8         |
+| Bonus Stats | +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This prototype was an early attempt to create means of deflecting blasts of raw primal energy. It was specifically built for the more nimble strike squads of Blue Exodus. |
+| **Obtain** | Located in [[Blue Exodus]]. Chest located at **(-2641, 32, 2126)**                                                                                                         |
+
+## S21C-"Falcon"
+
+|             |                    |
+| ----------- | ------------------ |
+| Enchants    | Unbreaking 8       |
+| Bonus Stats | +0.15 Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | This prototype was an early attempt to create means of deflecting blasts of raw primal energy. It was specifically built for the devastating powerhouse shock troops of Blue Exodus. |
+| **Obtain** | Located in [[Blue Exodus]]. Chest located at **(-2641, 32, 2126)**                                                                                                                   |
+
+## Sea Legs
+
+|          |                                              |
+| -------- | -------------------------------------------- |
+| Armor    | 3                                            |
+| Enchants | Respiration 1, Depth Strider 2, Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The treasured trousers of the eminent Captain Ihb himself. Originally an adventure novelist from the hinterland town of Kazanni, he lived a legendary life of adventure aboard his great ship, the Sharkfin, before disappearing along with Avsohm |
+| **Obtain** | Located in [[North Heartwood]]. Chest located at **(1787, 121, 3211)**                                                                                                                                                                                        |
+
+## Sepelitem
+
+|          |                         |
+| -------- | ----------------------- |
+| Enchants | Knockback 2, Silk Touch |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Not a single speck of dirt mars the polished bone of this ancient shovel. It was used once to bury the physical remains of Voynahla after their suicide, and once again to exhume their skull by Voynahla's orders. |
+| **Obtain** | Located in [[Voynahla]] on [[Lo'Dahr]]. Chest located at **(399, 84, 980)**                                                                                                                                         |
+
+## Sharksbane
+
+|          |         |
+| -------- | ------- |
+| Enchants | Punch 4 |
+
+|            | **Lore and how to Obtain**                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| **Lore**   | There are a total of 86 tallies carved into the varnished wood of this proud Eloan family heirloom.  |
+| **Obtain** | Located in [[Lorahn'Kahl]]. Item frame located at **(-597, 108, 4675)**                                   |
+
+## Shock
+
+|                |                      |
+| -------------- | -------------------- |
+| Attack Damage  | 18                   |
+| Movement Speed | 0.6                  |
+| Enchants       | Sweeping Edge 7      |
+| Bonus Stats    | -0.02 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | One of Amohn Aihura's two famous armaments. A wickedly curved greatsword that pulses with electricity. Legends speak of Amohn's heroics at the First Battle of Ytaj, when the Palaesidans overcame a Loyalist ambush led by Sereven to take the palace themselves. |
+| **Obtain** | Located in [[Palaesida]] on [[Lo'Dahr]]. Chest located at **(327, 42, 475)**                                                                                                                                                                                       |
+
+## Siege
+
+|               |                |
+| ------------- | -------------- |
+| Attack Damage | 10             |
+| Attack Speed  | 1.6            |
+| Bonus Stats   | +10 Max Health |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                               |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | It's an oft-ignored fact that Maelmari and Drehmari are cut from the same cloth. Both have a penchant for destruction. To spur their destructive tendencies, leaders of each race need only utter two words: "Lay siege" |
+| **Obtain** | Located in [[Carmine]]. Chest located at **(-2890, 124, 5211)**                                                                                                                                                             |
+
+## Skullhammer
+
+|               |                                     |
+| ------------- | ----------------------------------- |
+| Attack Damage | 7                                   |
+| Attack Speed  | 1.4                                 |
+| Enchants      | Unbreaking 2                        |
+| Bonus Stats   | -2 Max Health, +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | A crude bludgeoning weapon, wielded by only the most bloodthirsty of Maelmari. A horned skull is affixed to the top, with blunted crystal horns. Spoils of war, to be certain. |
+| **Obtain** | Located in [[North Tharxax]]. Chest located at **(-1648, 66, 2232)**                                                                                                                    |
+
+## Slime Chrysalis
+
+|             |                                                                         |
+| ----------- | ----------------------------------------------------------------------- |
+| Bonus Stats | +3% Max Health, +3% Movement Speed, +3% Attack Damage, +3% Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                               |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | A pleasant warmth emanates off this peculiar orb. While holding it, you can feel it gently writhe and begin to conform to the shape of your hand. It's oddly comforting. |
+| **Obtain** | Located in [[Slime Island]]. Chest located at **(-1225, 93, 3752)**                                                                                                      |
+
+## Sliming Trousers
+
+|                 |              |
+| --------------- | ------------ |
+| Armor           | 5            |
+| Armor Toughness | 2            |
+| Enchants        | Unbreaking 7 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                          |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The noble Drehmari of Semehol refined slime mined from the nearby island and delivered it to Tharxax City. When they rose up against Ethgar, the Third Burnt General, her army made an example of them. Only their reinforced working gear remains. |
+| **Obtain** | Located in [[South Tharxax]]. Chest located at **(-1682, 67, 3857)**                                                                                                                                                                                |
+
+## Smau's Hammer
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 9            |
+| Attack Speed  | 0.9          |
+| Enchants      | Unbreaking 4 |
+
+|            | **Lore and how to Obtain**               |
+| ---------- | ---------------------------------------- |
+| **Lore**   | The beloved axe of a former executioner. |
+| **Obtain** | Located in [[Av'Sal]]. Dropped by a mob. |
+
+## Snowsbane
+
+|               |                                           |
+| ------------- | ----------------------------------------- |
+| Attack Damage | 5                                         |
+| Attack Speed  | 1                                         |
+| Enchants      | Fire Aspect 4, Efficiency 3, Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This sturdy rune-emblazoned shovel radiates with an inner warmth. Developed by commission from the King of Highfall himself, these powerful artifacts are a modern necessity when living on the frozen tundra |
+| **Obtain** | Located in [[Highfall Tundra]]. Chest located at **(5087, 79, -2394)**                                                                                                                                                   |
+
+## Soilsplitter
+
+|               |                      |
+| ------------- | -------------------- |
+| Attack Damage | 10                   |
+| Attack Speed  | 1                    |
+| Bonus Stats   | +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Celiah Esipelli, the legendary founder of Esipelli Vineyard, reportedly obtained this hoe from Noha herself before her death on Lo'Dahr. An inscription on its varnished handle reads: "Continue my legacy." |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(1648, 91, -1349)**                                                                                                                                                  |
+
+## Sparkstoker
+
+|               |               |
+| ------------- | ------------- |
+| Attack Damage | 1             |
+| Attack Speed  | 4             |
+| Enchants      | Fire Aspect 7 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                          |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Lailoehn is known to have as much greed as the fire of his domain and twice as much pride, but he repays those who stroke with ego with light and protection. This tool was used to stoke a flame which burned throughout three consecutive Avihms. |
+| **Obtain** | Located in [[Mt. Ebonfire]]. Chest located at **(-3565, 162, 342)**                                                                                                                                                                                         |
+
+## Spherewalkers
+
+|                 |                                                       |
+| --------------- | ----------------------------------------------------- |
+| Armor           | 3                                                     |
+| Armor Toughness | 3                                                     |
+| Enchants        | Fire Protection 3, Feather Falling 3, Depth Strider 2 |
+| Bonus Stats     | +0.02 Movement Speed                                  |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | None expected that Raene, most devout among the alchemists, would turn to necromancy after conquering her third Sphere. Yet, by repeatedly killing a single prisoner, she broadcast a whisper to every serious practitioner: "Come to Lorahn'Kahl! The Great Work begins!" |
+| **Obtain** | Located in [[Lorahn'Kahl]]. Chest located at **(-1671, 22, 5232)**                                                                                                                                                                                                                |
+
+## Spiderweb Rod
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 5            |
+| Attack Speed  | 1.2          |
+| Enchants      | Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                              |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Masquerading as an average fishing pole, this trick weapon conceals a serrated blade in its handle. When a button is pressed, the line becomes sticky enough to ensnare very large prey |
+| **Obtain** | Located in [[Lorahn'Kahl]]. Chest located at **(45, 70, 5313)**                                                                                                                         |
+
+## Staff of Xenoh
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 5            |
+| Attack Speed  | 1            |
+| Enchants      | Efficiency 5 |
+
+|            | **Lore and how to Obtain**                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Rosefather Xenoh, friend of Noha, was buried here. After her premature demise, he traveled across the realm planting roses and watering them with his tears. |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(2997, 81, -1622)**                                                                                                  |
+
+## Starpiercer
+
+|               |             |
+| ------------- | ----------- |
+| Attack Damage | 7           |
+| Attack Speed  | 1.6         |
+| Enchants      | Sharpness 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Members of the Coven of Koh speak in hushed whispers about the fabled pickaxe which finally broke the Star of Alanys, a brutally jagged rock from elsewhere that glittered green and gold. |
+| **Obtain** | Located in [[Island of Dusk]]. Chest located at **(-2332, 87, -3804)**                                                                                                                               |
+
+## Steelspinner
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Enchants    | Knockback 4, Punch 2                |
+| Bonus Stats | +6 Max Health, -0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Only the bravest of the Seldom-Seen are assigned to watch over the caverns so close to the surface. To protect the throne of the Underliege from probing Two-Eyes is a solemn duty that is not taken lightly. |
+| **Obtain** | Located in [[Faehrcycle]]. Chest located at **(3627, 13, -2548)**                                                                                                                                                   |
+
+## Stoneshaper
+
+|               |                                     |
+| ------------- | ----------------------------------- |
+| Attack Damage | 3                                   |
+| Attack Speed  | 1.2                                 |
+| Enchants      | Efficiency 6, Unbreaking 3, Mending |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | The people of the ancient town of Wokonori worshipped the Triad of Taihgel, Koh, and Nahyn, as equals, and saw themselves as custodians of the earth gods' great gift. Stone seems to flow away slightly from the blade of this pickaxe as it draws near. |
+| **Obtain** | Located in [[Grand Pike Canyon]]. Chest located at **(4256, 42, -984)**                                                                                                                                                                                   |
+
+## Swallowtail
+
+|             |                                     |
+| ----------- | ----------------------------------- |
+| Enchants    | Multishot                           |
+| Bonus Stats | -4 Max Health, +0.01 Movement Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | This uniquely bifurcated crossbow belongs to one of the Benefactors, the La'Tehrmari leaders of the Wingmakers. The first Benefactor Froslea, always taught that a Wingmaker should travel as far as the bird can fly, so that no qualified Tehrmari candidate should ever be missed. |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(2731, 86, -414)**                                                                                                                                                                                                                            |
+
+## Sword of Artohris
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 7            |
+| Attack Speed  | 1.6          |
+| Enchants      | Unbreaking 4 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | This stored blade belonged to Artohris of Ancehl. Though he was the son of a nobleman, he was strong and virtuous. On his final mission, he attempted to make a journey alone to the Burnt Palace to fight Maelihs. Instead, he found his was to the Sepulchral Alter and became one of Maelihs' most trusted servants, before meeting his end on the battlefield. |
+| **Obtain** | Located on the Maerhn'Vos wall separating the [[Ebony Veldt]] and [[Merijool]]. Chest located at **(-2253, 119, -140)**                                                                                                                                                                                                                                                                                                       |
+
+## Talisman of Endless Growth
+
+|             |                                  |
+| ----------- | -------------------------------- |
+| Bonus Stats | +25% Armor, +10% Armor Toughness |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Chipped murals on ancient walls tell the story of the Great Revel. While Vayniklah's faithful hoped to revive the soul of the world, instead they opened the door to something far more sinister. |
+| **Obtain** | Located in [[Merijool]]. Chest located at **(-991, 77, -346)**                                                                                                                                        |
+
+## Temporal Bow
+
+|             |          |
+| ----------- | -------- |
+| Enchants    | Infinity |
+
+|            | **Lore and how to Obtain**                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | Avsohm advanced at such a rapid pace, it would be some time before that technology found its way into the hands of its people. |
+| **Obtain** | Inside an avsohmic-looking tower in northwestern [[Purity Peaks]]. Chest located at **(1747, 186, 109)**                       |
+
+## The Archduke's Scepter of Divine Insight
+
+|               |                                                                 |
+| ------------- | --------------------------------------------------------------- |
+| Attack Damage | 11                                                              |
+| Attack Speed  | 0.9                                                             |
+| Enchants      | Knockback 3, Looting 2, Unbreaking 3, Luck of the Sea 2, Lure 2 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                            |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Archduke Hishrin Elsahr Ombahr Drehn-Anyr Hovadchear Vahidson I is the sole monarch of the noble lands in West Faehrcycle. This sacred staff is proof of his noble lineage and Aspect-blessed wisdom. |
+| **Obtain** | Located in [[Faehrcycle]]. Chest located at **(1027, 99, -2999)**                                                                                                                                           |
+
+## The Immortal Slap Fish
+
+|          |             |
+| -------- | ----------- |
+| Enchants | Knockback 3 |
+
+|            | **Lore and how to Obtain**                                    |
+| ---------- | ------------------------------------------------------------- |
+| **Lore**   | Exactly what it says on the fin.                              |
+| **Obtain** | Located in [[Casai]]. Chest located at **(-2645, 67, -1097)** |
+
+## Tidal Root Mask
+
+|                 |                                                   |
+| --------------- | ------------------------------------------------- |
+| Armor           | 3                                                 |
+| Armor Toughness | 1                                                 |
+| Enchants        | Fire Protection 5, Aqua Affinity, Depth Strider 2 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                             |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | In the early year's of the Tide Queen's reign, relations with Gozak were positive and even celebrated. A yearly festival would take place at the center of Espinor's great bridge, even after the Dynasty's invasions. |
+| **Obtain** | Located on the bridge between [[South Heartwood]] and [[Black Jungle]]. Chest located at **(2623, 113, 3943)**                                                                                                         |
+
+## Timefall Boots
+
+|          |                            |
+| -------- | -------------------------- |
+| Armor    | 1                          |
+| Enchants | Feather Falling 4, Mending |
+
+|            | **Lore and how to Obtain**                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | One day, an Avsohmic scholar challenged themselves to create the most convoluted method at preventing injuries from heights - and thus these boots were made. |
+| **Obtain** | Located in [[Purity Peaks]]. Chest located at **(2218, 142, 515)**                                                                                                    |
+
+## Totem of Dying
+
+|             |     |
+| ----------- | --- |
+| Bonus Stats | +??? Max Health, +??? Movement Speed, +??? Attack Damage |
+
+|            | **Lore and how to Obtain**                                   |
+| ---------- | ------------------------------------------------------------ |
+| **Lore**   | Nihil! Nihil! NIHIL!                                                         |
+| **Obtain** | Located in [[Akhlo'Rohma]]. Chest located at **(2839, 114, -2046)** |
+
+## Unlimited Power
+
+|          |                   |
+| -------- | ----------------- |
+| Enchants | Infinity, Mending |
+
+|            | **Lore and how to Obtain**                                            |
+| ---------- | --------------------------------------------------------------------- |
+| **Lore**   | "Everything that has transpired has done so according to my plan."    |
+| **Obtain** | Located in [[North Tharxax]]. Chest located at **(-1721, 175, 1897)** |
+
+## Visionary's Crossbow
+
+|          |                                     |
+| -------- | ----------------------------------- |
+| Enchants | Unbreaking 2, Multishot, Piercing 2 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | The nations of Akhlo'Rohma have long been an oppressor to surrounding regions. Veruhkt, the most affected by their tyranny, has had their culture and people all but forgotten |
+| **Obtain** | Located at the top of the tallest tower within the ruins of Sal'Veruhkt in [[Veruhkt Plateau]]. Chest located at **(3588, 96, -1360)**                                                                                                                    |
+|            |                                                                                                                                                                                |
+
+## Vuxli's Stirring Rod
+
+|               |               |
+| ------------- | ------------- |
+| Attack Damage | 30            |
+| Attack Speed  | 0.1           |
+| Enchants      | Efficiency 10 |
+
+|            | **Lore and how to Obtain**                                                |
+| ---------- | ------------------------------------------------------------------------- |
+| **Lore**   | She makes the 'shine shine with this beaut'!                              |
+| **Obtain** | Located in [[Dahr]] on [[Lo'Dahr]]. Chest located at **(-1014, 45, 219)** |
+
+## Whimsical Shortsword
+
+|               |              |
+| ------------- | ------------ |
+| Attack Damage | 5            |
+| Attack Speed  | 2.5          |
+| Enchants      | Unbreaking 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Made of resilient steel, this shortsword sports a unique sporting hilt. Oddly, small figures of axolotls playing in a spring are prominently featured in shallow relief all along the blade. |
+| **Obtain** | Located in [[Lai]] on [[Lo'Dahr]]. Chest located at **(1370, 138, -1204)**                                                                                                                   |
+
+## Wish for Hope
+
+|             |                                                      |
+| ----------- | ---------------------------------------------------- |
+| Enchants    | Unbreaking 1                                         |
+| Bonus Stats | +15% Max Health, -5% Attack Damage, -5% Attack Speed |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lore**   | A pure white shortbow, fabled weapon of an old Virmari hero. During the Deity Wars, they were one of Virtuo's greatest crusaders against Maelihs and his armies. Though their name was forgotten, their heroic became the spirit of the Empire of Vir. |
+| **Obtain** | Located in [[Highfall Tundra]]. Chest located at **(4740, 126, -1169)**                                                                                                                                                                                           |
+
+## Worn Ironreed Rod
+
+|               |           |
+| ------------- | --------- |
+| Attack Damage | 7         |
+| Attack Speed  | 1.6       |
+| Enchants      | Looting 3 |
+
+|            | **Lore and how to Obtain**                                                                                                                                                                                                                                                                                                                     |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lore**   | Two friends grew up in the slums of the great river city of Athrah, long ago, and made a living as thieves. When one disappeared after trying to steal from a traveling order of monks, the other used the combined funds to buy this sturdy rod, which lifted them out of desperation. On a fateful day many decades later, the two reunited. |
+| **Obtain** | Located in [[Ytaj]] on [[Lo'Dahr]]. Chest located at **(29, 44, -1540)**                                                                                                                                                                                                                                                                       |
+
+## \_\_\_\_\_\_\_\_\_\_\_\_
+
+|             |                                                                            |
+| ----------- | -------------------------------------------------------------------------- |
+| Bonus Stats | +30 Max Health, -70% Movement Speed, -90% Attack Damage, -90% Attack Speed |
+
+|            | **Lore and how to Obtain**                                         |
+| ---------- | ------------------------------------------------------------------ |
+| **Lore**   | ...                                                                |
+| **Obtain** | Located in [[Black Jungle]]. Chest located at **(4291, 20, 4125)** |


### PR DESCRIPTION
Adds info from the artifact page of the [Drehmal v2.2 Apotheosis Beta Data Compendium doc](https://docs.google.com/spreadsheets/d/1M-jBeUXIXMsrOaCJUq3Vdzo2QlbA22NY_z558H1hwz0/edit?gid=868333405#gid=868333405&range=A1) using a script with most of the missing cells resolved.

Still needs a better description of how to obtain each relic as currently, most just state the general region along with the coordinates.

Not sure if all the artifacts are on there as I don't know how complete the Compendium is.