### PR TITLE
Add extra Header to set Site Title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,11 @@
+{% block extrahead %}
+  <script type="application/ld+json">
+    {
+      "@context" : "https://schema.org",
+      "@type" : "WebSite",
+      "name" : "Drehmal Wiki",
+      "url" : "https://wiki.drehmal.cyou/"
+    }
+  </script>
+  <meta property="og:site_name" content="Drehmal Wiki" />
+{% endblock %}


### PR DESCRIPTION
As per:

- https://mrkeo.github.io/reference/meta-tags/#customization
- https://developers.google.com/search/docs/appearance/site-names
- https://ogp.me/

Hopefully this will fix the site title during the next crawl.